### PR TITLE
removed posthog flagEnabled check

### DIFF
--- a/src/components/sanity/blocks/BlockContent.tsx
+++ b/src/components/sanity/blocks/BlockContent.tsx
@@ -51,7 +51,8 @@ export const BlockContent: FC<SanityBlockElement> = ({
     }
   }, [])
 
-  return flagEnabled !== undefined && blocks ? (
+  // TODO: FIX FLAG ENABLED CHECK
+  return blocks ? (
     <div className={className} style={style}>
       <PortableText
         value={blocks}


### PR DESCRIPTION
### Bug:
- Editing text on the "paris" page in sanity and attempting to publish it caused every page on the site to throw a 500 error because next couldn't parse an `undefined` value in sanity's sitesettings. I later diagnosed it as some strange discrepancy with posthog's `flagEnabled` check – not sure exactly why, but this needs to be fixed.

### Emergency Solution:
- Disable the check.

### Tradeoffs:
- Analytics and A/B testing suite may not function as expected until a more permanent fix is implemented.